### PR TITLE
Add Dexie-backed table and user lists

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,8 @@
       "name": "dexie-browser",
       "version": "0.0.0",
       "dependencies": {
+        "dexie": "^4.0.11",
+        "dexie-react-hooks": "^1.1.7",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
         "ygdrassil": "^2025.6.18"
@@ -1250,7 +1252,6 @@
       "version": "19.1.8",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.8.tgz",
       "integrity": "sha512-AwAfQ2Wa5bCx9WP8nZL2uMZWod7J7/JSplxbTmBQ5ms6QpqNYm672H0Vu9ZVKVngQ+ii4R/byguVEUZQyeg44g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.0.2"
@@ -1733,7 +1734,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/debug": {
@@ -1760,6 +1760,23 @@
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/dexie": {
+      "version": "4.0.11",
+      "resolved": "https://registry.npmjs.org/dexie/-/dexie-4.0.11.tgz",
+      "integrity": "sha512-SOKO002EqlvBYYKQSew3iymBoN2EQ4BDw/3yprjh7kAfFzjBYkaMNa/pZvcA7HSWlcKSQb9XhPe3wKyQ0x4A8A==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/dexie-react-hooks": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/dexie-react-hooks/-/dexie-react-hooks-1.1.7.tgz",
+      "integrity": "sha512-Lwv5W0Hk+uOW3kGnsU9GZoR1er1B7WQ5DSdonoNG+focTNeJbHW6vi6nBoX534VKI3/uwHebYzSw1fwY6a7mTw==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@types/react": ">=16",
+        "dexie": "^3.2 || ^4.0.1-alpha",
+        "react": ">=16"
+      }
     },
     "node_modules/dir-glob": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,9 @@
   "dependencies": {
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
-    "ygdrassil": "^2025.6.18"
+    "ygdrassil": "^2025.6.18",
+    "dexie": "^4.0.11",
+    "dexie-react-hooks": "^1.1.7"
   },
   "devDependencies": {
     "@eslint/js": "^9.29.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,3 @@
-import { useState } from 'react'
 import Main from './com/Main'
 
 import './App.css'

--- a/src/com/Main.tsx
+++ b/src/com/Main.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import {StateMachine, State} from 'ygdrassil'
 import Record from './Record'
 import Navigator from './Navigator'

--- a/src/com/Navigator.tsx
+++ b/src/com/Navigator.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import {StateButton} from 'ygdrassil'
 
 

--- a/src/com/Record/Edit.tsx
+++ b/src/com/Record/Edit.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+
 
 
 export default function RecordEdit() {

--- a/src/com/Record/List.tsx
+++ b/src/com/Record/List.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+
 
 
 export default function RecordList() {

--- a/src/com/Table/Edit.tsx
+++ b/src/com/Table/Edit.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+
 
 
 export default function TableEdit() {

--- a/src/com/Table/List.tsx
+++ b/src/com/Table/List.tsx
@@ -1,8 +1,18 @@
-import React from 'react'
-
+import { StateLink } from 'ygdrassil'
+import { db } from '../../db'
 
 export default function TableList() {
-  return (
-    <div>TableList</div>
-  )
+  const tables = db.tables.filter(t => !t.name.startsWith('$'))
+
+  return <div>
+    <h2>Tables</h2>
+    <ul>
+      {tables.map((t, i) => (
+        <li key={i}>
+          <StateLink to="table" data={{ id: t.name }}>{t.name}</StateLink>
+        </li>
+      ))}
+    </ul>
+  </div>
 }
+

--- a/src/com/User/Edit.tsx
+++ b/src/com/User/Edit.tsx
@@ -1,8 +1,43 @@
-import React from 'react'
-
+import { useLiveQuery } from 'dexie-react-hooks'
+import { useStateMachine } from 'ygdrassil'
+import { db } from '../../db'
 
 export default function UserEdit() {
-  return (
-    <div>UserEdit</div>
-  )
+  const { query, gotoState } = useStateMachine()
+  const id = Number(query.id)
+  const user = useLiveQuery(() => db.users.get(id), [id])
+
+  const save = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault()
+    const formData = new FormData(e.currentTarget)
+    const name = String(formData.get('name') || '')
+    const email = String(formData.get('email') || '')
+    await db.users.put({ id, name, email })
+    gotoState('users')
+  }
+
+  const remove = async () => {
+    if (confirm('Delete user?')) {
+      await db.users.delete(id)
+      gotoState('users')
+    }
+  }
+
+  if (!user) return <div>Loading...</div>
+
+  return <form onSubmit={save}>
+    <div>
+      <label>
+        Name <input name="name" defaultValue={user.name} />
+      </label>
+    </div>
+    <div>
+      <label>
+        Email <input name="email" defaultValue={user.email} />
+      </label>
+    </div>
+    <button type="submit">Save</button>
+    <button type="button" onClick={remove}>Delete</button>
+  </form>
 }
+

--- a/src/com/User/List.tsx
+++ b/src/com/User/List.tsx
@@ -1,8 +1,32 @@
-import React from 'react'
-
+import { useLiveQuery } from 'dexie-react-hooks'
+import { StateLink } from 'ygdrassil'
+import { db } from '../../db'
 
 export default function UserList() {
-  return (
-    <div>UserList</div>
-  )
+  const users = useLiveQuery(() => db.users.toArray(), [])
+
+  const addUser = async () => {
+    const name = prompt('Name?')
+    if (!name) return
+    const email = prompt('Email?') || ''
+    await db.users.add({ name, email })
+  }
+
+  const remove = async (id: number) => {
+    if (confirm('Delete user?')) await db.users.delete(id)
+  }
+
+  return <div>
+    <h2>Users</h2>
+    <button onClick={addUser}>Add User</button>
+    <ul>
+      {users?.map(u => (
+        <li key={u.id}>
+          <StateLink to="user" data={{ id: u.id! }}>{u.name}</StateLink>
+          <button onClick={() => remove(u.id!)}>Delete</button>
+        </li>
+      ))}
+    </ul>
+  </div>
 }
+

--- a/src/db.ts
+++ b/src/db.ts
@@ -1,0 +1,21 @@
+import Dexie from 'dexie'
+import type { Table } from 'dexie'
+
+export interface User {
+  id?: number
+  name: string
+  email: string
+}
+
+class AppDB extends Dexie {
+  users!: Table<User, number>
+
+  constructor() {
+    super('dexie-browser')
+    this.version(1).stores({
+      users: '++id, name, email'
+    })
+  }
+}
+
+export const db = new AppDB()

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "lib": ["ES2022", "DOM"],
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "verbatimModuleSyntax": true,
+    "jsx": "react-jsx",
+    "strict": true,
+    "skipLibCheck": true
+  }
+}


### PR DESCRIPTION
## Summary
- manage Dexie DB with new `db.ts`
- show available tables linking to table state
- list users with live updates and CRUD actions
- edit individual users
- support TypeScript build with `tsconfig.base.json`

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6866897976a483278d3d5da4d6a4068f