### PR TITLE
Add login widget

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "dexie": "^4.0.11",
+        "dexie-cloud-addon": "^4.0.12",
         "dexie-react-hooks": "^1.1.7",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
@@ -1767,6 +1768,31 @@
       "integrity": "sha512-SOKO002EqlvBYYKQSew3iymBoN2EQ4BDw/3yprjh7kAfFzjBYkaMNa/pZvcA7HSWlcKSQb9XhPe3wKyQ0x4A8A==",
       "license": "Apache-2.0"
     },
+    "node_modules/dexie-cloud-addon": {
+      "version": "4.0.12",
+      "resolved": "https://registry.npmjs.org/dexie-cloud-addon/-/dexie-cloud-addon-4.0.12.tgz",
+      "integrity": "sha512-zoaT0QTSujonhBa6iTnHhRt+Mdr3ka7FS6q51V32G278ul5KANMGH7rq9lxHxBbVshujPkMO7ekUCM6lDLoosw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "dexie-cloud-common": "^1.0.31",
+        "rxjs": "^7.x"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "dexie": "^4.0.11"
+      }
+    },
+    "node_modules/dexie-cloud-common": {
+      "version": "1.0.52",
+      "resolved": "https://registry.npmjs.org/dexie-cloud-common/-/dexie-cloud-common-1.0.52.tgz",
+      "integrity": "sha512-6ZSGZ4eYdWXfXnMvabvLySOlGl1s0UIt4B8V0j51aHvwUfEfcefJuBj41u51iTht7emIHjHNrz8GJmiean+3cQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "lib0": "^0.2.97"
+      }
+    },
     "node_modules/dexie-react-hooks": {
       "version": "1.1.7",
       "resolved": "https://registry.npmjs.org/dexie-react-hooks/-/dexie-react-hooks-1.1.7.tgz",
@@ -2385,6 +2411,16 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/isomorphic.js": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/isomorphic.js/-/isomorphic.js-0.2.5.tgz",
+      "integrity": "sha512-PIeMbHqMt4DnUP3MA/Flc0HElYjMXArsw1qwJZcm9sqR8mq3l8NYizFMty0pWwE/tzIGH3EKK5+jes5mAr85yw==",
+      "license": "MIT",
+      "funding": {
+        "type": "GitHub Sponsors ❤",
+        "url": "https://github.com/sponsors/dmonad"
+      }
+    },
     "node_modules/js-yaml": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
@@ -2453,6 +2489,27 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/lib0": {
+      "version": "0.2.109",
+      "resolved": "https://registry.npmjs.org/lib0/-/lib0-0.2.109.tgz",
+      "integrity": "sha512-jP0gbnyW0kwlx1Atc4dcHkBbrVAkdHjuyHxtClUPYla7qCmwIif1qZ6vQeJdR5FrOVdn26HvQT0ko01rgW7/Xw==",
+      "license": "MIT",
+      "dependencies": {
+        "isomorphic.js": "^0.2.4"
+      },
+      "bin": {
+        "0ecdsa-generate-keypair": "bin/0ecdsa-generate-keypair.js",
+        "0gentesthtml": "bin/gentesthtml.js",
+        "0serve": "bin/0serve.js"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "type": "GitHub Sponsors ❤",
+        "url": "https://github.com/sponsors/dmonad"
       }
     },
     "node_modules/locate-path": {
@@ -2926,6 +2983,15 @@
         "queue-microtask": "^1.2.2"
       }
     },
+    "node_modules/rxjs": {
+      "version": "7.8.2",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
+      "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
     "node_modules/scheduler": {
       "version": "0.26.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.26.0.tgz",
@@ -3124,6 +3190,12 @@
       "peerDependencies": {
         "typescript": ">=4.8.4"
       }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
     },
     "node_modules/type-check": {
       "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "react-dom": "^19.1.0",
     "ygdrassil": "^2025.6.18",
     "dexie": "^4.0.11",
-    "dexie-react-hooks": "^1.1.7"
+    "dexie-react-hooks": "^1.1.7",
+    "dexie-cloud-addon": "^4.0.12"
   },
   "devDependencies": {
     "@eslint/js": "^9.29.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,5 @@
 import Main from './com/Main'
+import LoginWidget from './com/LoginWidget'
 
 import './App.css'
 
@@ -10,6 +11,7 @@ export default function App() {
     <Main />
     
     <footer>
+      <LoginWidget />
       <p>Powered by Vite + React</p>
     </footer>
   </>

--- a/src/com/LoginWidget.tsx
+++ b/src/com/LoginWidget.tsx
@@ -1,0 +1,39 @@
+import { useEffect, useState } from 'react'
+import { db, login } from '../db'
+
+export default function LoginWidget() {
+  const [userName, setUserName] = useState<string | null>(null)
+  const [email, setEmail] = useState('')
+
+  useEffect(() => {
+    const sub = db.cloud.currentUser.subscribe(u => {
+      if (u && u.isLoggedIn) {
+        setUserName(u.name || u.email || u.userId || null)
+      } else {
+        setUserName(null)
+      }
+    })
+    return () => sub.unsubscribe()
+  }, [])
+
+  const submit = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault()
+    await login({ email })
+  }
+
+  if (userName) {
+    return <span>Logged in as {userName}</span>
+  }
+
+  return (
+    <form onSubmit={submit}>
+      <input
+        type="email"
+        placeholder="email"
+        value={email}
+        onChange={e => setEmail(e.target.value)}
+      />
+      <button type="submit">Login</button>
+    </form>
+  )
+}

--- a/src/db.ts
+++ b/src/db.ts
@@ -41,6 +41,6 @@ class AppDB extends Dexie {
 
 export const db = new AppDB()
 
-export async function login() {
-  await db.cloud.login()
+export async function login(hints?: { email?: string }) {
+  await db.cloud.login(hints)
 }


### PR DESCRIPTION
## Summary
- add `login` helper with email support
- create `<LoginWidget>` component
- show `<LoginWidget>` in the page footer
- install `dexie-cloud-addon` dependency

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686694d749f48327b34c46e1d18ea2c7