### PR TITLE
Fix Dexie Cloud initialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ While this is a standalone app, it is designed to be used as a template for your
 - `npx dexie-cloud create`
 - `npx dexie-cloud whitelist http://localhost:3000`
 - At this point, you should have `dexie-cloud.json` and `dexie-cloud.key` files in your project root.
+- Copy these files into the `public/` directory so the app can load them at runtime.
 - Create `roles.json`
 - `npx dexie-cloud import roles.json`
 

--- a/src/db.ts
+++ b/src/db.ts
@@ -3,7 +3,7 @@ import type { Table } from 'dexie'
 import dexieCloud from 'dexie-cloud-addon'
 
 const schema = {
-  version: 1,
+  version: 2,
   stores: {
     dataItems: "&uuid, userId, timestamp, name, value, [userId+timestamp]"
   }
@@ -33,7 +33,7 @@ class AppDB extends Dexie {
   constructor() {
     super('dexie-browser', {
       addons: [dexieCloud],
-      autoOpen: true,
+      autoOpen: false,
     })
     this.version(schema.version).stores(schema.stores)
   }
@@ -42,8 +42,29 @@ class AppDB extends Dexie {
 
 export const db = new AppDB()
 
+let initPromise: Promise<void> | null = null
+
+export async function initDb() {
+  if (!initPromise) {
+    initPromise = fetch('/dexie-cloud.json')
+      .then(r => r.json())
+      .then(async opts => {
+        db.cloud.configure(opts)
+        await db.open()
+      })
+  }
+  return initPromise
+}
+
+declare global {
+  interface Window {
+    db: AppDB
+  }
+}
+
 window.db = db // Expose db for debugging in browser console
 
 export async function login(hints?: { email?: string }) {
+  await initDb()
   await db.cloud.login(hints)
 }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,6 +2,11 @@ import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import './index.css'
 import App from './App.tsx'
+import { initDb } from './db'
+
+initDb().catch(err => {
+  console.error('Failed to initialize Dexie Cloud', err)
+})
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>


### PR DESCRIPTION
## Summary
- load Dexie Cloud config on startup
- open database only after configuration
- document where to place `dexie-cloud.json`

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686697d5608083278a00540aa92a134c