### PR TITLE
Implement table record browsing and add item

### DIFF
--- a/src/com/Record/List.tsx
+++ b/src/com/Record/List.tsx
@@ -1,8 +1,37 @@
-
-
+import { useLiveQuery } from 'dexie-react-hooks'
+import { useStateMachine } from 'ygdrassil'
+import { db } from '../../db'
+import type { Table } from 'dexie'
 
 export default function RecordList() {
+  const { query } = useStateMachine()
+  const tableName = String(query.id || '')
+  const table: Table<unknown, unknown> | null = tableName ? db.table(tableName) : null
+
+  const records = useLiveQuery(() => table?.toArray() ?? [], [table])
+
+  const addRecord = async () => {
+    if (!table) return
+    const json = prompt('Enter JSON for new item:')
+    if (!json) return
+    try {
+      await table.add(JSON.parse(json) as unknown)
+    } catch (err) {
+      alert('Failed to add item: ' + err)
+    }
+  }
+
+  if (!tableName) return <div>No table selected</div>
+
   return (
-    <div>RecordList</div>
+    <div>
+      <h2>Data for {tableName}</h2>
+      <button onClick={addRecord}>Add</button>
+      <ul>
+        {records?.map((rec, i) => (
+          <li key={i}>{JSON.stringify(rec)}</li>
+        ))}
+      </ul>
+    </div>
   )
 }

--- a/src/com/Table/List.tsx
+++ b/src/com/Table/List.tsx
@@ -9,7 +9,7 @@ export default function TableList() {
     <ul>
       {tables.map((t, i) => (
         <li key={i}>
-          <StateLink to="table" data={{ id: t.name }}>{t.name}</StateLink>
+          <StateLink to="data" data={{ id: t.name }}>{t.name}</StateLink>
         </li>
       ))}
     </ul>


### PR DESCRIPTION
## Summary
- link tables directly to the `data` state
- list records for the selected table and provide an Add button

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6866a2459bf88327a3e0472927f97d4d