### PR TITLE
Fix adding data item in Dexie Browser

### DIFF
--- a/src/com/Record/List.tsx
+++ b/src/com/Record/List.tsx
@@ -15,7 +15,13 @@ export default function RecordList() {
     const name = prompt('Name for new item?')
     if (!name) return
     try {
-      await table.add({ name } as unknown)
+      await table.add({
+        // Dexie Cloud tables require a string primary key
+        uuid: crypto.randomUUID(),
+        timestamp: Date.now(),
+        name,
+        value: ''
+      } as unknown)
     } catch (err) {
       alert('Failed to add item: ' + err)
     }


### PR DESCRIPTION
## Summary
- ensure new data items get a string PK
- auto-populate timestamp and value when creating an item

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6866a7f4a4f0832784f594027431b9dc