### PR TITLE
feat: prompt for dexie cloud config

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,7 @@ While this is a standalone app, it is designed to be used as a template for your
 
 - `npx dexie-cloud create`
 - `npx dexie-cloud whitelist http://localhost:3000`
-- At this point, you should have `dexie-cloud.json` and `dexie-cloud.key` files in your project root.
-- Copy these files into the `public/` directory so the app can load them at runtime.
+- When the app loads it will prompt for the Dexie Cloud connection details and store them in local storage.
 - Create `roles.json`
 - `npx dexie-cloud import roles.json`
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,6 @@
 import Main from './com/Main'
 import LoginWidget from './com/LoginWidget'
+import ConnectionManager from './com/ConnectionManager'
 
 import './App.css'
 
@@ -7,12 +8,13 @@ import './App.css'
 export default function App() {
   return <>
     <header>Dexie.js Data Browser</header>
-    
-    <Main />
-    
-    <footer>
-      <LoginWidget />
-      <p>Powered by Vite + React</p>
-    </footer>
+
+    <ConnectionManager>
+      <Main />
+      <footer>
+        <LoginWidget />
+        <p>Powered by Vite + React</p>
+      </footer>
+    </ConnectionManager>
   </>
 }

--- a/src/com/ConnectionManager.tsx
+++ b/src/com/ConnectionManager.tsx
@@ -1,0 +1,113 @@
+import { useState, useEffect } from 'react'
+import type { DexieCloudOptions } from 'dexie-cloud-addon'
+import { initDb } from '../db'
+
+interface Connection {
+  name: string
+  options: DexieCloudOptions
+  lastUsed: number
+}
+
+const STORAGE_KEY = 'dexieConnections'
+
+function loadConnections (): Connection[] {
+  if (typeof localStorage === 'undefined') return []
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY)
+    return raw ? (JSON.parse(raw) as Connection[]) : []
+  } catch {
+    return []
+  }
+}
+
+function saveConnections (conns: Connection[]) {
+  if (typeof localStorage === 'undefined') return
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(conns))
+}
+
+export default function ConnectionManager ({ children }: { children: React.ReactNode }) {
+  const [connections, setConnections] = useState<Connection[]>([])
+  const [connected, setConnected] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [form, setForm] = useState({ name: '', databaseUrl: '' })
+
+  useEffect(() => {
+    const list = loadConnections().sort((a, b) => b.lastUsed - a.lastUsed)
+    setConnections(list)
+  }, [])
+
+  useEffect(() => {
+    if (!connected && connections.length) {
+      connect(connections[0])
+    }
+  }, [connections, connected])
+
+  function connect (conn: Connection) {
+    setError(null)
+    initDb(conn.options).then(() => {
+      setConnected(true)
+      setConnections(prev => {
+        const updated = [
+          { ...conn, lastUsed: Date.now() },
+          ...prev.filter(c => c.name !== conn.name)
+        ]
+        saveConnections(updated)
+        return updated
+      })
+    }).catch(err => {
+      setError(String(err))
+    })
+  }
+
+  const submit = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault()
+    try {
+      const conn: Connection = {
+        name: form.name || form.databaseUrl,
+        options: { databaseUrl: form.databaseUrl },
+        lastUsed: Date.now()
+      }
+      setConnections(prev => {
+        const updated = [conn, ...prev]
+        saveConnections(updated)
+        return updated
+      })
+      connect(conn)
+    } catch (err) {
+      setError(String(err))
+    }
+  }
+
+  if (!connected) {
+    return <div>
+      <h2>Connect to Dexie Cloud</h2>
+      {error && <p>{error}</p>}
+      {connections.length > 0 && <div>
+        <h3>Saved Connections</h3>
+        <ul>
+          {connections.map(c => <li key={c.name}>
+            <button onClick={() => connect(c)}>{c.name}</button>
+          </li>)}
+        </ul>
+      </div>}
+      <form onSubmit={submit}>
+        <input
+          type="text"
+          placeholder="Name"
+          value={form.name}
+          onChange={e => setForm({ ...form, name: e.target.value })}
+        />
+        <input
+          type="text"
+          placeholder="Database URL"
+          value={form.databaseUrl}
+          onChange={e => setForm({ ...form, databaseUrl: e.target.value })}
+        />
+        <button type="submit">Connect</button>
+      </form>
+    </div>
+  }
+
+  return <>{children}</>
+}
+

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,11 +2,6 @@ import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import './index.css'
 import App from './App.tsx'
-import { initDb } from './db'
-
-initDb().catch(err => {
-  console.error('Failed to initialize Dexie Cloud', err)
-})
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>


### PR DESCRIPTION
## Summary
- prompt for dexie cloud configuration and store multiple connections in local storage
- allow connecting to the most recently used database

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run build` *(fails: Argument of type is not assignable to parameter of type Optional<DBRealmMember>)*

------
https://chatgpt.com/codex/tasks/task_e_68beecdfe1f883279c76fa84402534dc