### PR TITLE
feat: add table viewer and placeholders for roles and realms

### DIFF
--- a/src/com/Main.tsx
+++ b/src/com/Main.tsx
@@ -3,7 +3,8 @@ import Record from './Record'
 import Navigator from './Navigator'
 import User from './User'
 import Table from './Table'
-
+import Role from './Role'
+import Realm from './Realm'
 
 export default function Main() {
   return <main>
@@ -20,13 +21,25 @@ export default function Main() {
         <Table.List />
       </State>
       <State name="table">
-        <Table.Edit />
+        <Table.Viewer />
       </State>
-      <State name="data">
-        <Record.List />
+      <State name="table-edit">
+        <Table.Edit />
       </State>
       <State name="record">
         <Record.Edit />
+      </State>
+      <State name="roles">
+        <Role.List />
+      </State>
+      <State name="role">
+        <Role.Edit />
+      </State>
+      <State name="realms">
+        <Realm.List />
+      </State>
+      <State name="realm">
+        <Realm.Edit />
       </State>
     </StateMachine>
   </main>

--- a/src/com/Navigator.tsx
+++ b/src/com/Navigator.tsx
@@ -1,9 +1,10 @@
 import {StateButton} from 'ygdrassil'
 
-
 export default function Navigator() {
   return <div>
     <StateButton to="tables" />
     <StateButton to="users" />
+    <StateButton to="realms" />
+    <StateButton to="roles" />
   </div>
 }

--- a/src/com/Realm/Edit.tsx
+++ b/src/com/Realm/Edit.tsx
@@ -1,0 +1,3 @@
+export default function RealmEdit() {
+  return <div>Edit Realm - TODO</div>
+}

--- a/src/com/Realm/List.tsx
+++ b/src/com/Realm/List.tsx
@@ -1,0 +1,8 @@
+export default function RealmList() {
+  return (
+    <div>
+      <h2>Realms</h2>
+      <p>Realm management is not implemented yet.</p>
+    </div>
+  )
+}

--- a/src/com/Realm/index.tsx
+++ b/src/com/Realm/index.tsx
@@ -1,9 +1,7 @@
 import Edit from './Edit'
 import List from './List'
-import Viewer from './Viewer'
 
 export default {
   Edit,
   List,
-  Viewer,
 }

--- a/src/com/Role/Edit.tsx
+++ b/src/com/Role/Edit.tsx
@@ -1,0 +1,3 @@
+export default function RoleEdit() {
+  return <div>Edit Role - TODO</div>
+}

--- a/src/com/Role/List.tsx
+++ b/src/com/Role/List.tsx
@@ -1,0 +1,8 @@
+export default function RoleList() {
+  return (
+    <div>
+      <h2>Roles</h2>
+      <p>Role management is not implemented yet.</p>
+    </div>
+  )
+}

--- a/src/com/Role/index.tsx
+++ b/src/com/Role/index.tsx
@@ -1,9 +1,7 @@
 import Edit from './Edit'
 import List from './List'
-import Viewer from './Viewer'
 
 export default {
   Edit,
   List,
-  Viewer,
 }

--- a/src/com/Table/List.tsx
+++ b/src/com/Table/List.tsx
@@ -9,10 +9,9 @@ export default function TableList() {
     <ul>
       {tables.map((t, i) => (
         <li key={i}>
-          <StateLink to="data" data={{ id: t.name }}>{t.name}</StateLink>
+          <StateLink to="table" data={{ id: t.name }}>{t.name}</StateLink>
         </li>
       ))}
     </ul>
   </div>
 }
-

--- a/src/com/Table/Viewer.tsx
+++ b/src/com/Table/Viewer.tsx
@@ -1,0 +1,42 @@
+import { useLiveQuery } from 'dexie-react-hooks'
+import { useStateMachine } from 'ygdrassil'
+import { db } from '../../db'
+import type { Table as DexieTable } from 'dexie'
+
+export default function TableViewer() {
+  const { query } = useStateMachine()
+  const tableName = String(query.id || '')
+  const table: DexieTable<unknown, unknown> | null = tableName ? db.table(tableName) : null
+
+  const records = useLiveQuery(() => table?.toArray() ?? [], [table])
+
+  const addRecord = async () => {
+    if (!table) return
+    const name = prompt('Name for new item?')
+    if (!name) return
+    try {
+      await table.add({
+        uuid: crypto.randomUUID(),
+        timestamp: Date.now(),
+        name,
+        value: ''
+      } as unknown)
+    } catch (err) {
+      alert('Failed to add item: ' + err)
+    }
+  }
+
+  if (!tableName) return <div>No table selected</div>
+
+  return (
+    <div>
+      <h2>Data for {tableName}</h2>
+      <button onClick={addRecord}>Add</button>
+      <ul>
+        {records?.map((rec, i) => (
+          <li key={i}>{JSON.stringify(rec)}</li>
+        ))}
+      </ul>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- show table data when a table is selected
- navigate between tables, users, realms, and roles
- add placeholder components for realms and roles

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68beef60e8e08327921be0f22eb2d14c