### PR TITLE
Fix user edits reverting and add realms listing

### DIFF
--- a/src/com/Realm/Edit.tsx
+++ b/src/com/Realm/Edit.tsx
@@ -1,3 +1,19 @@
+import { useLiveQuery } from 'dexie-react-hooks'
+import { useStateMachine } from 'ygdrassil'
+import { db } from '../../db'
+
 export default function RealmEdit() {
-  return <div>Edit Realm - TODO</div>
+  const { query } = useStateMachine()
+  const id = String(query.id)
+  const realm = useLiveQuery(() => db.realms.get(id), [id])
+
+  if (!realm) return <div>Loading...</div>
+
+  return (
+    <div>
+      <h2>{realm.name || realm.realmId}</h2>
+      <div>Realm ID: {realm.realmId}</div>
+      {realm.owner && <div>Owner: {realm.owner}</div>}
+    </div>
+  )
 }

--- a/src/com/Realm/List.tsx
+++ b/src/com/Realm/List.tsx
@@ -1,8 +1,28 @@
+import { useLiveQuery } from 'dexie-react-hooks'
+import { StateLink } from 'ygdrassil'
+import { db } from '../../db'
+
 export default function RealmList() {
+  const realms = useLiveQuery(async () => {
+    const user = db.cloud.currentUser.value
+    if (!user?.userId) return []
+    const memberships = await db.members.where('userId').equals(user.userId).toArray()
+    const realmIds = Array.from(new Set(memberships.map(m => m.realmId)))
+    if (!realmIds.length) return []
+    const res = await db.realms.bulkGet(realmIds)
+    return res.filter((r): r is NonNullable<typeof r> => !!r)
+  }, [])
+
   return (
     <div>
       <h2>Realms</h2>
-      <p>Realm management is not implemented yet.</p>
+      <ul>
+        {realms?.map(r => (
+          <li key={r.realmId}>
+            <StateLink to="realm" data={{ id: r.realmId }}>{r.name || r.realmId}</StateLink>
+          </li>
+        ))}
+      </ul>
     </div>
   )
 }

--- a/src/com/User/Edit.tsx
+++ b/src/com/User/Edit.tsx
@@ -12,8 +12,7 @@ export default function UserEdit() {
     const formData = new FormData(e.currentTarget)
     const name = String(formData.get('name') || '')
     const email = String(formData.get('email') || '')
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    await db.members.put({ id, name, email } as any)
+    await db.members.update(id, { name, email })
     gotoState('users')
   }
 


### PR DESCRIPTION
## Summary
- Preserve user changes by updating member records instead of overwriting them
- List realms accessible to the current user and display basic realm details

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68befd7f53248327b96c8f9501e6652c