### PR TITLE
refactor: move Dexie schema to separate module

### DIFF
--- a/src/db.ts
+++ b/src/db.ts
@@ -2,14 +2,7 @@ import Dexie from 'dexie'
 import type { Table } from 'dexie'
 import dexieCloud from 'dexie-cloud-addon'
 import type { DexieCloudOptions } from 'dexie-cloud-addon'
-
-const schema = {
-  version: 2,
-  stores: {
-    // compound index: unique uuid, plus quick per‑user chronological queries
-    dataItems: '&uuid, userId, timestamp, name, value, [userId+timestamp]'
-  }
-}
+import { schema } from './schema'
 
 export interface DataItem {
   uuid: string

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -1,0 +1,7 @@
+export const schema = {
+  version: 2,
+  stores: {
+    // compound index: unique uuid, plus quick per-user chronological queries
+    dataItems: '&uuid, userId, timestamp, name, value, [userId+timestamp]'
+  }
+}


### PR DESCRIPTION
## Summary
- refactor: separate Dexie schema definition into its own module and import it in db

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68beff5464888327bba95cddba6c01ab