### PR TITLE
Load schema from CLI export

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,20 @@ While this is a standalone app, it is designed to be used as a template for your
 - `npx dexie-cloud import roles.json`
 
 
+## Provide Schema
+
+Administrators need to supply the application with a description of the tables
+and their primary keys. The easiest way is to export the database schema using
+the Dexie Cloud CLI:
+
+- `npx dexie-cloud export --json > public/export.json`
+
+The generated `export.json` file contains a top-level `schema` object mapping
+each table to its primary key specification. Place this file in the `public`
+folder and restart the app. The schema drives the generic data grids for all
+tables except **Users**, **Realms**, and **Roles**.
+
+
 ## Cruft
 
 Pragmatically, most of this app is cruft—beyond the basic CRUD functionality, it is mostly optional.

--- a/src/com/Table/List.tsx
+++ b/src/com/Table/List.tsx
@@ -2,7 +2,8 @@ import { StateLink } from 'ygdrassil'
 import { db } from '../../db'
 
 export default function TableList() {
-  const tables = db.tables.filter(t => !t.name.startsWith('$'))
+  const hidden = new Set(['users', 'realms', 'roles'])
+  const tables = db.tables.filter(t => !t.name.startsWith('$') && !hidden.has(t.name))
 
   return <div>
     <h2>Tables</h2>

--- a/src/com/Table/Viewer.tsx
+++ b/src/com/Table/Viewer.tsx
@@ -1,26 +1,35 @@
+import { useEffect, useState } from 'react'
 import { useLiveQuery } from 'dexie-react-hooks'
 import { useStateMachine } from 'ygdrassil'
 import { db } from '../../db'
+import { loadSchema, primaryKeyField } from '../../schema'
 import type { Table as DexieTable } from 'dexie'
 
 export default function TableViewer() {
   const { query } = useStateMachine()
   const tableName = String(query.id || '')
   const table: DexieTable<unknown, unknown> | null = tableName ? db.table(tableName) : null
-
   const records = useLiveQuery(() => table?.toArray() ?? [], [table])
+  const [pkField, setPkField] = useState<string | null>(null)
+
+  useEffect(() => {
+    loadSchema().then(sch => {
+      const spec = sch[tableName]
+      setPkField(spec ? primaryKeyField(spec) : null)
+    })
+  }, [tableName])
 
   const addRecord = async () => {
-    if (!table) return
-    const name = prompt('Name for new item?')
-    if (!name) return
+    if (!table || !pkField) return
+    const json = prompt('New record (JSON)?', '{}')
+    if (!json) return
     try {
-      await table.add({
-        uuid: crypto.randomUUID(),
-        timestamp: Date.now(),
-        name,
-        value: ''
-      } as unknown)
+      const rec = JSON.parse(json) as Record<string, unknown>
+      if (!rec[pkField]) {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (rec as any)[pkField] = crypto.randomUUID()
+      }
+      await table.add(rec as unknown)
     } catch (err) {
       alert('Failed to add item: ' + err)
     }

--- a/src/db.ts
+++ b/src/db.ts
@@ -1,53 +1,39 @@
 import Dexie from 'dexie'
-import type { Table } from 'dexie'
 import dexieCloud from 'dexie-cloud-addon'
 import type { DexieCloudOptions } from 'dexie-cloud-addon'
-import { schema } from './schema'
+import { loadSchema } from './schema'
 
-export interface DataItem {
-  uuid: string
-  userId: string // Dexie Cloud subject id is string, not number
-  timestamp: number
-  name: string
-  value: string
-}
-
-class AppDB extends Dexie {
-  dataItems!: Table<DataItem, string>
-
-  constructor () {
-    super('dexie-browser', {
-      addons: [dexieCloud],
-      autoOpen: false
-    })
-
-    this.version(schema.version).stores(schema.stores)
-  }
-}
-
-export const db = new AppDB()
+export let db: Dexie
 
 export async function initDb (opts: DexieCloudOptions) {
-  if (db.isOpen()) return
+  if (db?.isOpen()) return
 
   if (!opts.databaseUrl) {
     throw new Error('databaseUrl is required')
   }
 
+  const stores = await loadSchema()
+  db = new Dexie('dexie-browser', {
+    addons: [dexieCloud],
+    autoOpen: false
+  })
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  db.version(1).stores(stores as any)
+
   db.cloud.configure(opts)
   await db.open()
+
+  if (typeof window !== 'undefined') {
+    window.db = db
+  }
 }
 
 declare global {
-  interface Window { db: AppDB }
-}
-
-if (typeof window !== 'undefined') {
-  window.db = db // for devtools
+  interface Window { db: Dexie }
 }
 
 export async function login (hints?: { email?: string }) {
-  if (!db.isOpen()) {
+  if (!db?.isOpen()) {
     throw new Error('Database not initialized')
   }
   await db.cloud.login(hints)


### PR DESCRIPTION
## Summary
- document how admins can provide a `schema` by exporting with `dexie-cloud` CLI
- read schema from `export.json` to configure Dexie and generic data grids
- hide Users/Realms/Roles from generic table list and load PK info for adding records

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c1a36102f08327b5cb05ba65e3c36b