### PR TITLE
feat: add dexie cloud settings and api helpers

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -55,3 +55,104 @@
   display: flex;
   gap: 0.5rem;
 }
+
+.settings {
+  max-width: 720px;
+  margin: 0 auto;
+  text-align: left;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.settings-description {
+  margin: 0;
+  font-size: 0.95rem;
+  color: rgba(255, 255, 255, 0.75);
+}
+
+.settings-form {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.settings-form fieldset {
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  border-radius: 8px;
+  padding: 1rem 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.settings-form legend {
+  font-weight: 600;
+  padding: 0 0.5rem;
+}
+
+.settings-form label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  font-size: 0.95rem;
+}
+
+.settings-form label span {
+  font-weight: 500;
+}
+
+.settings-form input,
+.settings-form select {
+  border-radius: 6px;
+  border: 1px solid rgba(255, 255, 255, 0.25);
+  padding: 0.5rem 0.75rem;
+  font-size: 1rem;
+  background-color: rgba(255, 255, 255, 0.05);
+  color: inherit;
+}
+
+.settings-form input:focus,
+.settings-form select:focus {
+  outline: 2px solid #646cff;
+  outline-offset: 2px;
+}
+
+.settings-form .checkbox {
+  flex-direction: row;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.settings-form .checkbox input[type='checkbox'] {
+  width: auto;
+  accent-color: #646cff;
+}
+
+.settings-actions {
+  display: flex;
+  gap: 0.75rem;
+  justify-content: flex-end;
+  flex-wrap: wrap;
+}
+
+.settings-status {
+  margin: 0;
+  font-size: 0.95rem;
+}
+
+@media (prefers-color-scheme: light) {
+  .settings-description {
+    color: rgba(0, 0, 0, 0.65);
+  }
+
+  .settings-form fieldset {
+    border-color: rgba(0, 0, 0, 0.12);
+  }
+
+  .settings-form input,
+  .settings-form select {
+    border-color: rgba(0, 0, 0, 0.16);
+    background-color: rgba(0, 0, 0, 0.03);
+  }
+}

--- a/src/com/ConnectionManager.tsx
+++ b/src/com/ConnectionManager.tsx
@@ -1,26 +1,86 @@
-import { useState, useEffect } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import type { DexieCloudOptions } from 'dexie-cloud-addon'
 import { initDb } from '../db'
+import {
+  DEXIE_CLOUD_CREDENTIAL_STORAGE_KEY,
+  createDexieCloudOptions,
+  credentialsAreComplete,
+  loadStoredCredentials
+} from '../lib/dexieCloudApi'
+import Settings from './Settings'
 
 export default function ConnectionManager ({ children }: { children: React.ReactNode }) {
   const [connected, setConnected] = useState(false)
   const [error, setError] = useState<string | null>(null)
+  const [loading, setLoading] = useState(true)
+  const lastCredentialSignature = useRef<string | null>(null)
 
   useEffect(() => {
-    fetch('/dexie-cloud.json')
-      .then(resp => {
-        if (!resp.ok) throw new Error(`HTTP ${resp.status}`)
-        return resp.json()
-      })
-      .then((opts: DexieCloudOptions) => initDb(opts))
-      .then(() => setConnected(true))
-      .catch(err => setError(String(err)))
+    let disposed = false
+    let pending = false
+
+    const connect = async (force = false) => {
+      if (pending) return
+      pending = true
+      setLoading(true)
+      setError(null)
+
+      try {
+        const credentials = loadStoredCredentials()
+        if (!credentialsAreComplete(credentials)) {
+          if (!disposed) {
+            setConnected(false)
+            setError('Dexie Cloud credentials are not configured. Use the Settings view to provide them.')
+          }
+          return
+        }
+
+        const signature = JSON.stringify(credentials)
+        const shouldForce = force || lastCredentialSignature.current !== signature
+        const options: DexieCloudOptions = createDexieCloudOptions(credentials)
+        await initDb(options, { force: shouldForce })
+        if (!disposed) {
+          lastCredentialSignature.current = signature
+          setConnected(true)
+          setError(null)
+        }
+      } catch (err) {
+        if (!disposed) {
+          setConnected(false)
+          setError(err instanceof Error ? err.message : String(err))
+        }
+      } finally {
+        pending = false
+        if (!disposed) {
+          setLoading(false)
+        }
+      }
+    }
+
+    connect()
+
+    const handleStorageChange = (event: StorageEvent | CustomEvent<{ key: string }>) => {
+      const key = event instanceof StorageEvent ? event.key : event.detail?.key
+      if (!key || key !== DEXIE_CLOUD_CREDENTIAL_STORAGE_KEY) return
+      void connect(true)
+    }
+
+    window.addEventListener('storage', handleStorageChange as EventListener)
+    window.addEventListener('localStorageUpdate', handleStorageChange as EventListener)
+
+    return () => {
+      disposed = true
+      window.removeEventListener('storage', handleStorageChange as EventListener)
+      window.removeEventListener('localStorageUpdate', handleStorageChange as EventListener)
+    }
   }, [])
 
   if (!connected) {
-    return <div>
-      <h2>Connecting to Dexie Cloud</h2>
+    return <div className="connection-gate">
+      <h2>Dexie Cloud Connection</h2>
+      {loading ? <p>Connecting to Dexie Cloud…</p> : <p>Not connected.</p>}
       {error && <p>{error}</p>}
+      <Settings />
     </div>
   }
 

--- a/src/com/Main.tsx
+++ b/src/com/Main.tsx
@@ -5,6 +5,7 @@ import User from './User'
 import Table from './Table'
 import Role from './Role'
 import Realm from './Realm'
+import Settings from './Settings'
 
 export default function Main() {
   return <main>
@@ -40,6 +41,9 @@ export default function Main() {
       </State>
       <State name="realm">
         <Realm.Edit />
+      </State>
+      <State name="settings">
+        <Settings />
       </State>
     </StateMachine>
   </main>

--- a/src/com/Navigator.tsx
+++ b/src/com/Navigator.tsx
@@ -6,5 +6,6 @@ export default function Navigator() {
     <StateButton to="users" />
     <StateButton to="realms" />
     <StateButton to="roles" />
+    <StateButton to="settings">Settings</StateButton>
   </div>
 }

--- a/src/com/Settings.tsx
+++ b/src/com/Settings.tsx
@@ -1,0 +1,213 @@
+import { useState } from 'react'
+import type { FormEvent } from 'react'
+import useLocalStorage from '../hook/useLocalStorage'
+import { initDb } from '../db'
+import {
+  DEFAULT_CREDENTIALS,
+  DEXIE_CLOUD_CREDENTIAL_STORAGE_KEY,
+  createDexieCloudOptions
+} from '../lib/dexieCloudApi'
+import type { DexieCloudCredentials } from '../lib/dexieCloudApi'
+
+export default function Settings () {
+  const [credentials, setCredentials] = useLocalStorage<DexieCloudCredentials>(
+    DEXIE_CLOUD_CREDENTIAL_STORAGE_KEY,
+    { ...DEFAULT_CREDENTIALS }
+  )
+  const [status, setStatus] = useState<string | null>(null)
+  const [testing, setTesting] = useState(false)
+
+  const updateCredentials = (patch: Partial<DexieCloudCredentials>) => {
+    setCredentials(prev => ({ ...prev, ...patch }))
+  }
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    setTesting(true)
+    setStatus(null)
+
+    try {
+      const options = createDexieCloudOptions(credentials)
+      await initDb(options, { force: true })
+      setStatus('Connection successful. The database is ready to use.')
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err)
+      setStatus(`Connection failed: ${message}`)
+    } finally {
+      setTesting(false)
+    }
+  }
+
+  const handleReset = () => {
+    setCredentials({ ...DEFAULT_CREDENTIALS })
+    setStatus('Credentials cleared. Update the fields and test the connection again.')
+  }
+
+  const handlePeriodicSyncChange = (value: string) => {
+    if (value === '') {
+      updateCredentials({ periodicSyncIntervalMinutes: undefined })
+      return
+    }
+    const parsed = Number(value)
+    updateCredentials({
+      periodicSyncIntervalMinutes: Number.isNaN(parsed) ? undefined : parsed
+    })
+  }
+
+  return (
+    <section className="settings">
+      <h2>Dexie Cloud Settings</h2>
+      <p className="settings-description">
+        Provide the credentials for your Dexie Cloud instance. The values are stored locally in
+        your browser so they can be reused the next time you open the app.
+      </p>
+      <form className="settings-form" onSubmit={handleSubmit}>
+        <fieldset>
+          <legend>Connection</legend>
+          <label>
+            <span>Database URL</span>
+            <input
+              type="url"
+              required
+              placeholder="https://your-database.dexie.cloud"
+              value={credentials.databaseUrl}
+              onChange={event => updateCredentials({ databaseUrl: event.target.value })}
+            />
+          </label>
+          <label>
+            <span>API Key</span>
+            <input
+              type="text"
+              placeholder="Optional API key"
+              value={credentials.apiKey ?? ''}
+              onChange={event => updateCredentials({ apiKey: event.target.value })}
+            />
+          </label>
+          <label>
+            <span>Access Token</span>
+            <input
+              type="text"
+              placeholder="Bearer token for direct HTTP calls"
+              value={credentials.accessToken ?? ''}
+              onChange={event => updateCredentials({ accessToken: event.target.value })}
+            />
+          </label>
+        </fieldset>
+
+        <fieldset>
+          <legend>Authentication</legend>
+          <label className="checkbox">
+            <input
+              type="checkbox"
+              checked={Boolean(credentials.requireAuth)}
+              onChange={event => updateCredentials({ requireAuth: event.target.checked })}
+            />
+            Require authentication on startup
+          </label>
+          <label>
+            <span>Default login email</span>
+            <input
+              type="email"
+              placeholder="user@example.com"
+              value={credentials.defaultEmail ?? ''}
+              onChange={event => updateCredentials({ defaultEmail: event.target.value })}
+            />
+          </label>
+          <label>
+            <span>OAuth client ID</span>
+            <input
+              type="text"
+              value={credentials.clientId ?? ''}
+              onChange={event => updateCredentials({ clientId: event.target.value })}
+            />
+          </label>
+          <label>
+            <span>OAuth client secret</span>
+            <input
+              type="password"
+              autoComplete="new-password"
+              value={credentials.clientSecret ?? ''}
+              onChange={event => updateCredentials({ clientSecret: event.target.value })}
+            />
+          </label>
+          <label>
+            <span>Token endpoint</span>
+            <input
+              type="url"
+              placeholder="Defaults to /token"
+              value={credentials.tokenUrl ?? ''}
+              onChange={event => updateCredentials({ tokenUrl: event.target.value })}
+            />
+          </label>
+          <label>
+            <span>Audience</span>
+            <input
+              type="text"
+              value={credentials.audience ?? ''}
+              onChange={event => updateCredentials({ audience: event.target.value })}
+            />
+          </label>
+        </fieldset>
+
+        <fieldset>
+          <legend>Sync</legend>
+          <label className="checkbox">
+            <input
+              type="checkbox"
+              checked={Boolean(credentials.tryUseServiceWorker)}
+              onChange={event => updateCredentials({ tryUseServiceWorker: event.target.checked })}
+            />
+            Try to use a service worker
+          </label>
+          <label className="checkbox">
+            <input
+              type="checkbox"
+              checked={Boolean(credentials.disableWebSocket)}
+              onChange={event => updateCredentials({ disableWebSocket: event.target.checked })}
+            />
+            Disable WebSocket connections
+          </label>
+          <label className="checkbox">
+            <input
+              type="checkbox"
+              checked={Boolean(credentials.disableEagerSync)}
+              onChange={event => updateCredentials({ disableEagerSync: event.target.checked })}
+            />
+            Disable eager sync
+          </label>
+          <label>
+            <span>Periodic sync interval (minutes)</span>
+            <input
+              type="number"
+              min="0"
+              step="1"
+              value={credentials.periodicSyncIntervalMinutes ?? ''}
+              onChange={event => handlePeriodicSyncChange(event.target.value)}
+            />
+          </label>
+        </fieldset>
+
+        <fieldset>
+          <legend>Schema</legend>
+          <label>
+            <span>Export path</span>
+            <input
+              type="text"
+              placeholder="/export"
+              value={credentials.exportPath ?? ''}
+              onChange={event => updateCredentials({ exportPath: event.target.value })}
+            />
+          </label>
+        </fieldset>
+
+        <div className="settings-actions">
+          <button type="submit" disabled={testing}>Test &amp; Save</button>
+          <button type="button" onClick={handleReset} disabled={testing}>Reset</button>
+        </div>
+        {status && (
+          <p className="settings-status" aria-live="polite">{status}</p>
+        )}
+      </form>
+    </section>
+  )
+}

--- a/src/db.ts
+++ b/src/db.ts
@@ -5,11 +5,19 @@ import { loadSchema } from './schema'
 
 export let db: Dexie
 
-export async function initDb (opts: DexieCloudOptions) {
-  if (db?.isOpen()) return
-
+export async function initDb (opts: DexieCloudOptions, options: { force?: boolean } = {}) {
   if (!opts.databaseUrl) {
     throw new Error('databaseUrl is required')
+  }
+
+  if (db?.isOpen()) {
+    const currentUrl = db.cloud?.options?.databaseUrl
+    if (!options.force && currentUrl === opts.databaseUrl) {
+      return
+    }
+    db.close()
+  } else if (db) {
+    db.close()
   }
 
   const stores = await loadSchema()

--- a/src/hook/useLocalStorage.d.ts
+++ b/src/hook/useLocalStorage.d.ts
@@ -1,0 +1,8 @@
+declare function useLocalStorage<T>(
+  key: string,
+  defaultValue: T
+): [T, (value: T | ((prev: T) => T)) => void]
+
+export default useLocalStorage
+
+export function getItem<T = unknown>(key: string): T | null

--- a/src/lib/dexieCloudApi.ts
+++ b/src/lib/dexieCloudApi.ts
@@ -1,0 +1,282 @@
+import type { DexieCloudOptions } from 'dexie-cloud-addon'
+import type { TokenFinalResponse } from 'dexie-cloud-common'
+
+export interface DexieCloudCredentials {
+  databaseUrl: string
+  apiKey?: string
+  accessToken?: string
+  clientId?: string
+  clientSecret?: string
+  tokenUrl?: string
+  audience?: string
+  requireAuth?: boolean
+  defaultEmail?: string
+  tryUseServiceWorker?: boolean
+  disableWebSocket?: boolean
+  disableEagerSync?: boolean
+  periodicSyncIntervalMinutes?: number
+  exportPath?: string
+}
+
+export const DEXIE_CLOUD_CREDENTIAL_STORAGE_KEY = 'dexie-browser/dexie-cloud-credentials'
+
+export const DEFAULT_CREDENTIALS: DexieCloudCredentials = {
+  databaseUrl: '',
+  apiKey: '',
+  accessToken: '',
+  clientId: '',
+  clientSecret: '',
+  tokenUrl: '',
+  audience: '',
+  requireAuth: false,
+  defaultEmail: '',
+  tryUseServiceWorker: true,
+  disableWebSocket: false,
+  disableEagerSync: false,
+  periodicSyncIntervalMinutes: undefined,
+  exportPath: ''
+}
+
+export type DexieCloudSchemaDefinition = Record<string, string>
+
+export interface DexieCloudRequestOptions extends Omit<RequestInit, 'body'> {
+  body?: unknown
+  query?: Record<string, string | number | boolean | undefined>
+  parseJson?: boolean
+}
+
+export function mergeWithDefaultCredentials (
+  value?: Partial<DexieCloudCredentials> | null
+): DexieCloudCredentials {
+  return {
+    ...DEFAULT_CREDENTIALS,
+    ...value
+  }
+}
+
+export function loadStoredCredentials (): DexieCloudCredentials | null {
+  if (typeof window === 'undefined') return null
+  const raw = window.localStorage.getItem(DEXIE_CLOUD_CREDENTIAL_STORAGE_KEY)
+  if (!raw) return null
+  try {
+    const parsed = JSON.parse(raw) as Partial<DexieCloudCredentials>
+    return mergeWithDefaultCredentials(parsed)
+  } catch (err) {
+    console.warn('Failed to parse stored Dexie Cloud credentials', err)
+    return null
+  }
+}
+
+export function credentialsAreComplete (
+  credentials: DexieCloudCredentials | null
+): credentials is DexieCloudCredentials {
+  return Boolean(credentials?.databaseUrl && credentials.databaseUrl.trim().length > 0)
+}
+
+export function createDexieCloudOptions (
+  credentials: DexieCloudCredentials
+): DexieCloudOptions {
+  const baseUrl = normalizeBaseUrl(credentials.databaseUrl)
+  const options: DexieCloudOptions = {
+    databaseUrl: baseUrl,
+    customLoginGui: true
+  }
+
+  const defaultEmail = optionalString(credentials.defaultEmail)
+  if (defaultEmail) {
+    options.requireAuth = { email: defaultEmail }
+  } else if (credentials.requireAuth) {
+    options.requireAuth = true
+  }
+
+  if (typeof credentials.tryUseServiceWorker === 'boolean') {
+    options.tryUseServiceWorker = credentials.tryUseServiceWorker
+  }
+  if (typeof credentials.disableWebSocket === 'boolean') {
+    options.disableWebSocket = credentials.disableWebSocket
+  }
+  if (typeof credentials.disableEagerSync === 'boolean') {
+    options.disableEagerSync = credentials.disableEagerSync
+  }
+
+  if (
+    typeof credentials.periodicSyncIntervalMinutes === 'number' &&
+    !Number.isNaN(credentials.periodicSyncIntervalMinutes) &&
+    credentials.periodicSyncIntervalMinutes > 0
+  ) {
+    options.periodicSync = {
+      minInterval: credentials.periodicSyncIntervalMinutes * 60
+    }
+  }
+
+  const clientId = optionalString(credentials.clientId)
+  const clientSecret = optionalString(credentials.clientSecret)
+  const tokenUrl = optionalString(credentials.tokenUrl)
+  const audience = optionalString(credentials.audience)
+
+  if (clientId && clientSecret) {
+    const endpoint = buildAbsoluteUrl(tokenUrl ?? '/token', baseUrl)
+    options.fetchTokens = async ({ public_key, hints }) => {
+      const payload: Record<string, unknown> = {
+        client_id: clientId,
+        client_secret: clientSecret,
+        public_key,
+        hints,
+        grant_type: 'client_credentials'
+      }
+      if (audience) {
+        payload.audience = audience
+      }
+      const response = await fetch(endpoint, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify(payload)
+      })
+      if (!response.ok) {
+        const detail = await response.text().catch(() => response.statusText)
+        throw new Error(`Token request failed (${response.status}): ${detail}`)
+      }
+      return await response.json() as TokenFinalResponse
+    }
+  }
+
+  return options
+}
+
+export async function dexieCloudRequest<T> (
+  credentials: DexieCloudCredentials,
+  path: string,
+  { query, body, parseJson, headers, ...init }: DexieCloudRequestOptions = {}
+): Promise<T> {
+  const baseUrl = normalizeBaseUrl(credentials.databaseUrl)
+  const url = new URL(resolvePath(path), ensureTrailingSlash(baseUrl))
+
+  if (query) {
+    for (const [key, value] of Object.entries(query)) {
+      if (value === undefined || value === null) continue
+      url.searchParams.set(key, String(value))
+    }
+  }
+
+  const mergedHeaders = new Headers(headers)
+  if (
+    body !== undefined &&
+    !(body instanceof FormData) &&
+    typeof body !== 'string' &&
+    !mergedHeaders.has('Content-Type')
+  ) {
+    mergedHeaders.set('Content-Type', 'application/json')
+  }
+
+  if (credentials.apiKey && !mergedHeaders.has('X-Api-Key')) {
+    mergedHeaders.set('X-Api-Key', credentials.apiKey)
+  }
+  if (credentials.accessToken && !mergedHeaders.has('Authorization')) {
+    mergedHeaders.set('Authorization', `Bearer ${credentials.accessToken}`)
+  }
+
+  const requestInit: RequestInit = {
+    ...init,
+    headers: mergedHeaders
+  }
+
+  if (body !== undefined) {
+    if (
+      mergedHeaders.get('Content-Type') === 'application/json' &&
+      typeof body !== 'string' &&
+      !(body instanceof Blob) &&
+      !(body instanceof ArrayBuffer) &&
+      !(body instanceof URLSearchParams)
+    ) {
+      requestInit.body = JSON.stringify(body)
+    } else {
+      requestInit.body = body as BodyInit
+    }
+  }
+
+  const response = await fetch(url.toString(), requestInit)
+  if (!response.ok) {
+    const detail = await response.text().catch(() => response.statusText)
+    throw new Error(`Dexie Cloud request failed (${response.status}): ${detail}`)
+  }
+
+  if (requestInit.method === 'HEAD' || response.status === 204) {
+    return undefined as T
+  }
+
+  const shouldParseJson = parseJson ?? true
+  if (!shouldParseJson) {
+    return await response.text() as unknown as T
+  }
+
+  try {
+    const clone = response.clone()
+    return await clone.json() as T
+  } catch {
+    const fallback = await response.text().catch(() => '')
+    throw new Error(
+      fallback
+        ? `Failed to parse JSON response: ${fallback}`
+        : 'Failed to parse JSON response'
+    )
+  }
+}
+
+export async function fetchDexieCloudSchema (
+  credentials: DexieCloudCredentials
+): Promise<DexieCloudSchemaDefinition> {
+  const path = optionalString(credentials.exportPath) ?? '/export'
+  const result = await dexieCloudRequest<{ schema?: DexieCloudSchemaDefinition } | DexieCloudSchemaDefinition>(
+    credentials,
+    path,
+    {
+      query: { format: 'json' }
+    }
+  )
+
+  if (result && typeof result === 'object' && 'schema' in result) {
+    const schema = (result as { schema?: DexieCloudSchemaDefinition }).schema
+    if (schema && typeof schema === 'object') {
+      return schema
+    }
+  }
+
+  if (result && typeof result === 'object') {
+    return result as DexieCloudSchemaDefinition
+  }
+
+  throw new Error('Dexie Cloud export did not include a schema description')
+}
+
+export function ensureTrailingSlash (url: string): string {
+  return url.endsWith('/') ? url : `${url}/`
+}
+
+function normalizeBaseUrl (url: string): string {
+  const trimmed = url.trim()
+  if (!trimmed) {
+    throw new Error('Dexie Cloud database URL is required')
+  }
+  return trimmed.replace(/\/+$/, '')
+}
+
+function resolvePath (path: string): string {
+  if (!path) return '/' // default to root
+  return path.startsWith('/') ? path : `/${path}`
+}
+
+function buildAbsoluteUrl (maybeRelative: string, baseUrl: string): string {
+  try {
+    return new URL(maybeRelative, ensureTrailingSlash(baseUrl)).toString()
+  } catch {
+    return ensureTrailingSlash(baseUrl) + maybeRelative.replace(/^\//, '')
+  }
+}
+
+function optionalString (value?: string | null): string | undefined {
+  if (typeof value !== 'string') return undefined
+  const trimmed = value.trim()
+  return trimmed.length > 0 ? trimmed : undefined
+}

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -1,9 +1,27 @@
+import {
+  credentialsAreComplete,
+  fetchDexieCloudSchema,
+  loadStoredCredentials
+} from './lib/dexieCloudApi'
+
 export type Schema = Record<string, string>
 
 let cached: Schema | undefined
 
 export async function loadSchema (): Promise<Schema> {
   if (cached) return cached
+
+  const credentials = loadStoredCredentials()
+  if (credentialsAreComplete(credentials)) {
+    try {
+      const schema = await fetchDexieCloudSchema(credentials)
+      cached = schema
+      return cached
+    } catch (err) {
+      console.warn('Failed to load schema from Dexie Cloud export', err)
+    }
+  }
+
   try {
     const resp = await fetch('/export.json')
     if (!resp.ok) throw new Error(`HTTP ${resp.status}`)


### PR DESCRIPTION
## Summary
- add a dexieCloudApi helper module for building cloud options, performing authenticated requests, and loading remote schema data
- create a settings state with a form-backed component that stores Dexie Cloud credentials in local storage and styles for the new UI
- update the connection manager and schema loader to use stored credentials and support reconfiguring the Dexie instance when settings change

## Testing
- npm run build
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cd834b2aac832782548518ea6c39a3