### PR TITLE
Add known database management UI

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,8 +15,6 @@
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "ygdrassil": "^2025.6.18",
-    "dexie": "^4.0.11",
-    "dexie-react-hooks": "^1.1.7",
     "dexie-cloud-addon": "^4.0.12"
   },
   "devDependencies": {

--- a/src/App.css
+++ b/src/App.css
@@ -129,6 +129,19 @@
   accent-color: #646cff;
 }
 
+.settings-known-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-top: 0.5rem;
+}
+
+.settings-empty {
+  margin: 0;
+  font-size: 0.95rem;
+  color: rgba(255, 255, 255, 0.7);
+}
+
 .settings-actions {
   display: flex;
   gap: 0.75rem;
@@ -154,5 +167,9 @@
   .settings-form select {
     border-color: rgba(0, 0, 0, 0.16);
     background-color: rgba(0, 0, 0, 0.03);
+  }
+
+  .settings-empty {
+    color: rgba(0, 0, 0, 0.6);
   }
 }

--- a/src/com/Settings.tsx
+++ b/src/com/Settings.tsx
@@ -1,25 +1,200 @@
-import { useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import type { FormEvent } from 'react'
 import useLocalStorage from '../hook/useLocalStorage'
 import { initDb } from '../db'
 import {
   DEFAULT_CREDENTIALS,
   DEXIE_CLOUD_CREDENTIAL_STORAGE_KEY,
-  createDexieCloudOptions
+  createDexieCloudOptions,
+  mergeWithDefaultCredentials
 } from '../lib/dexieCloudApi'
 import type { DexieCloudCredentials } from '../lib/dexieCloudApi'
+import {
+  KNOWN_DATABASES_STORAGE_KEY,
+  SELECTED_KNOWN_DATABASE_ID_STORAGE_KEY,
+  createKnownDatabase,
+  normalizeKnownDatabases,
+  type KnownDatabase
+} from '../lib/knownDatabases'
+
+const DEFAULT_DATABASE_NAME = 'New database'
+
+function areCredentialsEqual (
+  a: DexieCloudCredentials,
+  b: DexieCloudCredentials
+): boolean {
+  return JSON.stringify(a) === JSON.stringify(b)
+}
+
+function ensureUniqueName (base: string, names: string[]): string {
+  const normalized = new Set(names.map(name => name.trim().toLowerCase()))
+  const trimmedBase = base.trim()
+  const fallback = trimmedBase.length > 0 ? trimmedBase : DEFAULT_DATABASE_NAME
+  if (!normalized.has(fallback.toLowerCase())) {
+    return fallback
+  }
+  let index = 2
+  let candidate = `${fallback} ${index}`.trim()
+  while (normalized.has(candidate.trim().toLowerCase())) {
+    index += 1
+    candidate = `${fallback} ${index}`.trim()
+  }
+  return candidate
+}
+
+function guessDatabaseName (
+  credentials: DexieCloudCredentials,
+  existingNames: string[]
+): string {
+  const url = credentials.databaseUrl?.trim()
+  if (url) {
+    try {
+      const parsed = new URL(url)
+      const base = parsed.hostname || parsed.pathname || url
+      return ensureUniqueName(base, existingNames)
+    } catch {
+      return ensureUniqueName(url, existingNames)
+    }
+  }
+  return ensureUniqueName(DEFAULT_DATABASE_NAME, existingNames)
+}
+
+function getDatabaseLabel (database: KnownDatabase): string {
+  const name = database.name.trim()
+  if (name.length > 0) return name
+  const url = database.credentials.databaseUrl.trim()
+  if (url.length > 0) return url
+  return 'Untitled database'
+}
 
 export default function Settings () {
   const [credentials, setCredentials] = useLocalStorage<DexieCloudCredentials>(
     DEXIE_CLOUD_CREDENTIAL_STORAGE_KEY,
     { ...DEFAULT_CREDENTIALS }
   )
+  const [knownDatabases, setKnownDatabases] = useLocalStorage<KnownDatabase[]>(
+    KNOWN_DATABASES_STORAGE_KEY,
+    []
+  )
+  const [selectedDatabaseId, setSelectedDatabaseId] = useLocalStorage<string | null>(
+    SELECTED_KNOWN_DATABASE_ID_STORAGE_KEY,
+    null
+  )
   const [status, setStatus] = useState<string | null>(null)
   const [testing, setTesting] = useState(false)
+  const hasKnownDatabases = knownDatabases.length > 0
+  const selectedDatabase = hasKnownDatabases
+    ? (selectedDatabaseId
+      ? knownDatabases.find(database => database.id === selectedDatabaseId) ?? knownDatabases[0]
+      : knownDatabases[0])
+    : null
+  const migrationDoneRef = useRef(false)
+
+  useEffect(() => {
+    setKnownDatabases(current => normalizeKnownDatabases(current))
+  }, [setKnownDatabases])
+
+  useEffect(() => {
+    setCredentials(prev => mergeWithDefaultCredentials(prev))
+  }, [setCredentials])
+
+  useEffect(() => {
+    if (migrationDoneRef.current) return
+    if (knownDatabases.length > 0) {
+      migrationDoneRef.current = true
+      return
+    }
+
+    const normalizedCredentials = mergeWithDefaultCredentials(credentials)
+    if (areCredentialsEqual(normalizedCredentials, DEFAULT_CREDENTIALS)) {
+      migrationDoneRef.current = true
+      return
+    }
+
+    const initialDatabase = createKnownDatabase(
+      guessDatabaseName(normalizedCredentials, []),
+      normalizedCredentials
+    )
+    migrationDoneRef.current = true
+    setKnownDatabases([initialDatabase])
+    setSelectedDatabaseId(initialDatabase.id)
+    setCredentials(initialDatabase.credentials)
+  }, [credentials, knownDatabases.length, setKnownDatabases, setSelectedDatabaseId, setCredentials])
+
+  useEffect(() => {
+    if (knownDatabases.length === 0) {
+      if (selectedDatabaseId !== null) {
+        setSelectedDatabaseId(null)
+      }
+      return
+    }
+
+    const selected = selectedDatabaseId
+      ? knownDatabases.find(database => database.id === selectedDatabaseId)
+      : undefined
+    const activeDatabase = selected ?? knownDatabases[0]
+
+    if (!selected || selectedDatabaseId === null) {
+      if (selectedDatabaseId !== activeDatabase.id) {
+        setSelectedDatabaseId(activeDatabase.id)
+      }
+    }
+
+    if (!areCredentialsEqual(credentials, activeDatabase.credentials)) {
+      setCredentials(activeDatabase.credentials)
+    }
+  }, [credentials, knownDatabases, selectedDatabaseId, setCredentials, setSelectedDatabaseId])
 
   const updateCredentials = (patch: Partial<DexieCloudCredentials>) => {
-    setCredentials(prev => ({ ...prev, ...patch }))
+    setCredentials(prev => {
+      const updated = { ...prev, ...patch }
+      if (selectedDatabase) {
+        const targetId = selectedDatabase.id
+        setKnownDatabases(current => current.map(database => (
+          database.id === targetId
+            ? { ...database, credentials: updated }
+            : database
+        )))
+      }
+      return updated
+    })
   }
+
+  const handleSelectDatabase = (id: string) => {
+    setSelectedDatabaseId(id || null)
+    setStatus(null)
+  }
+
+  const handleRenameDatabase = (name: string) => {
+    if (!selectedDatabase) return
+    const targetId = selectedDatabase.id
+    setKnownDatabases(current => current.map(database => (
+      database.id === targetId
+        ? { ...database, name }
+        : database
+    )))
+  }
+
+  const handleAddDatabase = () => {
+    setKnownDatabases(current => {
+      const existingNames = current.map(database => database.name)
+      const name = guessDatabaseName(credentials, existingNames)
+      const newDatabase = createKnownDatabase(name, credentials)
+      setSelectedDatabaseId(newDatabase.id)
+      setCredentials(newDatabase.credentials)
+      setStatus(null)
+      return [...current, newDatabase]
+    })
+  }
+
+  const handleDeleteDatabase = () => {
+    if (!selectedDatabase) return
+    const targetId = selectedDatabase.id
+    setKnownDatabases(current => current.filter(database => database.id !== targetId))
+    setStatus(null)
+  }
+
+  const selectedOptionValue = selectedDatabase?.id ?? selectedDatabaseId ?? (hasKnownDatabases ? knownDatabases[0].id : '')
 
   const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault()
@@ -39,7 +214,16 @@ export default function Settings () {
   }
 
   const handleReset = () => {
-    setCredentials({ ...DEFAULT_CREDENTIALS })
+    const resetCredentials = mergeWithDefaultCredentials({})
+    setCredentials(resetCredentials)
+    if (selectedDatabase) {
+      const targetId = selectedDatabase.id
+      setKnownDatabases(current => current.map(database => (
+        database.id === targetId
+          ? { ...database, credentials: resetCredentials }
+          : database
+      )))
+    }
     setStatus('Credentials cleared. Update the fields and test the connection again.')
   }
 
@@ -62,6 +246,48 @@ export default function Settings () {
         your browser so they can be reused the next time you open the app.
       </p>
       <form className="settings-form" onSubmit={handleSubmit}>
+        <fieldset>
+          <legend>Known databases</legend>
+          {hasKnownDatabases ? (
+            <>
+              <label>
+                <span>Saved databases</span>
+                <select
+                  value={selectedOptionValue}
+                  onChange={event => handleSelectDatabase(event.target.value)}
+                >
+                  {knownDatabases.map(database => (
+                    <option key={database.id} value={database.id}>{getDatabaseLabel(database)}</option>
+                  ))}
+                </select>
+              </label>
+              {selectedDatabase && (
+                <label>
+                  <span>Display name</span>
+                  <input
+                    type="text"
+                    placeholder="Database name"
+                    value={selectedDatabase.name}
+                    onChange={event => handleRenameDatabase(event.target.value)}
+                  />
+                </label>
+              )}
+            </>
+          ) : (
+            <p className="settings-empty">No known databases saved yet. Add one to quickly switch between Dexie Cloud instances.</p>
+          )}
+          <div className="settings-known-actions">
+            <button type="button" onClick={handleAddDatabase}>Add database</button>
+            <button
+              type="button"
+              onClick={handleDeleteDatabase}
+              disabled={!hasKnownDatabases}
+            >
+              Delete selected
+            </button>
+          </div>
+        </fieldset>
+
         <fieldset>
           <legend>Connection</legend>
           <label>
@@ -122,7 +348,7 @@ export default function Settings () {
             />
           </label>
           <label>
-            <span>OAuth client secret</span>
+            <span>Client secret</span>
             <input
               type="password"
               autoComplete="new-password"

--- a/src/lib/knownDatabases.ts
+++ b/src/lib/knownDatabases.ts
@@ -1,0 +1,38 @@
+import { DEFAULT_CREDENTIALS, mergeWithDefaultCredentials } from './dexieCloudApi'
+import type { DexieCloudCredentials } from './dexieCloudApi'
+
+export interface KnownDatabase {
+  id: string
+  name: string
+  credentials: DexieCloudCredentials
+}
+
+export const KNOWN_DATABASES_STORAGE_KEY = 'dexie-browser/known-databases'
+export const SELECTED_KNOWN_DATABASE_ID_STORAGE_KEY = 'dexie-browser/known-databases/selected-id'
+
+export function createKnownDatabase (
+  name: string,
+  credentials: Partial<DexieCloudCredentials> = DEFAULT_CREDENTIALS
+): KnownDatabase {
+  return {
+    id: createId(),
+    name,
+    credentials: mergeWithDefaultCredentials(credentials)
+  }
+}
+
+export function normalizeKnownDatabases (
+  databases: KnownDatabase[]
+): KnownDatabase[] {
+  return databases.map(database => ({
+    ...database,
+    credentials: mergeWithDefaultCredentials(database.credentials)
+  }))
+}
+
+function createId (): string {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID()
+  }
+  return Math.random().toString(36).slice(2, 12)
+}


### PR DESCRIPTION
## Summary
- persist a list of known Dexie databases in local storage and keep the selected credentials in sync
- add settings UI to add, rename, delete and choose saved databases with matching styles
- remove duplicate dependency entries from package.json to avoid build warnings

## Testing
- npm run lint
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ce9b9f81dc832796a79be81e59cf27