### PR TITLE
Wire settings selection into state machine

### DIFF
--- a/src/lib/dexieCloudCredentials.ts
+++ b/src/lib/dexieCloudCredentials.ts
@@ -1,0 +1,44 @@
+export interface DexieCloudCredentials {
+  databaseUrl: string
+  apiKey?: string
+  accessToken?: string
+  clientId?: string
+  clientSecret?: string
+  tokenUrl?: string
+  audience?: string
+  requireAuth?: boolean
+  defaultEmail?: string
+  tryUseServiceWorker?: boolean
+  disableWebSocket?: boolean
+  disableEagerSync?: boolean
+  periodicSyncIntervalMinutes?: number
+  exportPath?: string
+}
+
+export const DEXIE_CLOUD_CREDENTIAL_STORAGE_KEY = 'dexie-browser/dexie-cloud-credentials'
+
+export const DEFAULT_CREDENTIALS: DexieCloudCredentials = {
+  databaseUrl: '',
+  apiKey: '',
+  accessToken: '',
+  clientId: '',
+  clientSecret: '',
+  tokenUrl: '',
+  audience: '',
+  requireAuth: false,
+  defaultEmail: '',
+  tryUseServiceWorker: true,
+  disableWebSocket: false,
+  disableEagerSync: false,
+  periodicSyncIntervalMinutes: undefined,
+  exportPath: ''
+}
+
+export function mergeWithDefaultCredentials (
+  value?: Partial<DexieCloudCredentials> | null
+): DexieCloudCredentials {
+  return {
+    ...DEFAULT_CREDENTIALS,
+    ...value
+  }
+}

--- a/src/lib/knownDatabases.ts
+++ b/src/lib/knownDatabases.ts
@@ -1,5 +1,8 @@
-import { DEFAULT_CREDENTIALS, mergeWithDefaultCredentials } from './dexieCloudApi'
-import type { DexieCloudCredentials } from './dexieCloudApi'
+import {
+  DEFAULT_CREDENTIALS,
+  mergeWithDefaultCredentials,
+  type DexieCloudCredentials
+} from './dexieCloudCredentials'
 
 export interface KnownDatabase {
   id: string
@@ -9,6 +12,7 @@ export interface KnownDatabase {
 
 export const KNOWN_DATABASES_STORAGE_KEY = 'dexie-browser/known-databases'
 export const SELECTED_KNOWN_DATABASE_ID_STORAGE_KEY = 'dexie-browser/known-databases/selected-id'
+export const SELECTED_KNOWN_DATABASE_QUERY_KEY = 'dexie-db'
 
 export function createKnownDatabase (
   name: string,
@@ -30,9 +34,79 @@ export function normalizeKnownDatabases (
   }))
 }
 
+export function loadKnownDatabasesFromStorage (): KnownDatabase[] {
+  if (typeof window === 'undefined') return []
+  const raw = window.localStorage.getItem(KNOWN_DATABASES_STORAGE_KEY)
+  if (!raw) return []
+  try {
+    const parsed = JSON.parse(raw)
+    if (!Array.isArray(parsed)) return []
+    return normalizeKnownDatabases(parsed as KnownDatabase[])
+  } catch (err) {
+    console.warn('Failed to parse stored known databases', err)
+    return []
+  }
+}
+
+export function loadStoredSelectedKnownDatabaseId (): string | null {
+  if (typeof window === 'undefined') return null
+  const raw = window.localStorage.getItem(SELECTED_KNOWN_DATABASE_ID_STORAGE_KEY)
+  if (!raw) return null
+  try {
+    return normalizeId(JSON.parse(raw))
+  } catch (err) {
+    console.warn('Failed to parse stored known database selection', err)
+    return null
+  }
+}
+
+export function readSelectedKnownDatabaseIdFromQuery (
+  query?: Record<string, string | number> | null | undefined
+): string | null {
+  if (!query) return null
+  return normalizeId(query[SELECTED_KNOWN_DATABASE_QUERY_KEY])
+}
+
+export function readSelectedKnownDatabaseIdFromUrl (hash?: string): string | null {
+  if (typeof window === 'undefined' && typeof hash !== 'string') return null
+  const source = typeof hash === 'string' ? hash : window.location.hash
+  if (!source) return null
+
+  const trimmed = source.startsWith('#') ? source.slice(1) : source
+  const search = trimmed.startsWith('?') ? trimmed.slice(1) : trimmed
+  if (!search) return null
+
+  const params = new URLSearchParams(search)
+  return normalizeId(params.get(SELECTED_KNOWN_DATABASE_QUERY_KEY))
+}
+
+export function resolveActiveKnownDatabase (
+  databases: KnownDatabase[],
+  preferredId?: string | null
+): KnownDatabase | null {
+  if (databases.length === 0) return null
+  const normalizedId = normalizeId(preferredId)
+  if (normalizedId) {
+    const match = databases.find(database => database.id === normalizedId)
+    if (match) return match
+  }
+  return databases[0]
+}
+
 function createId (): string {
   if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
     return crypto.randomUUID()
   }
   return Math.random().toString(36).slice(2, 12)
+}
+
+function normalizeId (value: unknown): string | null {
+  if (typeof value === 'string') {
+    const trimmed = value.trim()
+    return trimmed.length > 0 ? trimmed : null
+  }
+  if (typeof value === 'number') {
+    return String(value)
+  }
+  return null
 }

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -1,36 +1,66 @@
 import {
   credentialsAreComplete,
   fetchDexieCloudSchema,
-  loadStoredCredentials
+  loadStoredCredentials,
+  type DexieCloudCredentials
 } from './lib/dexieCloudApi'
 
 export type Schema = Record<string, string>
 
 let cached: Schema | undefined
+let cachedSignature: string | null = null
+
+function createSchemaSignature (credentials: DexieCloudCredentials | null): string | null {
+  if (!credentialsAreComplete(credentials)) return null
+  return JSON.stringify({
+    databaseUrl: credentials.databaseUrl.trim(),
+    apiKey: normalizeOptional(credentials.apiKey),
+    accessToken: normalizeOptional(credentials.accessToken),
+    exportPath: normalizeOptional(credentials.exportPath)
+  })
+}
+
+function normalizeOptional (value?: string | null): string {
+  if (typeof value !== 'string') return ''
+  return value.trim()
+}
 
 export async function loadSchema (): Promise<Schema> {
-  if (cached) return cached
-
   const credentials = loadStoredCredentials()
+  const signature = createSchemaSignature(credentials)
+  const normalizedSignature = signature ?? 'fallback'
+
+  if (cached && cachedSignature === normalizedSignature) {
+    return cached
+  }
+
   if (credentialsAreComplete(credentials)) {
     try {
       const schema = await fetchDexieCloudSchema(credentials)
       cached = schema
+      cachedSignature = normalizedSignature
       return cached
     } catch (err) {
       console.warn('Failed to load schema from Dexie Cloud export', err)
+      if (cached && cachedSignature === 'fallback') {
+        return cached
+      }
     }
   }
 
-  try {
-    const resp = await fetch('/export.json')
-    if (!resp.ok) throw new Error(`HTTP ${resp.status}`)
-    const json = await resp.json()
-    cached = json.schema ?? {}
-  } catch (err) {
-    console.warn('Failed to load schema from export.json', err)
-    cached = {}
+  if (!cached || cachedSignature !== 'fallback') {
+    try {
+      const resp = await fetch('/export.json')
+      if (!resp.ok) throw new Error(`HTTP ${resp.status}`)
+      const json = await resp.json()
+      cached = json.schema ?? {}
+    } catch (err) {
+      console.warn('Failed to load schema from export.json', err)
+      cached = {}
+    }
   }
+
+  cachedSignature = 'fallback'
   return cached as Schema
 }
 


### PR DESCRIPTION
## Summary
- add a dedicated dexieCloudCredentials module so credentials defaults can be shared without circular imports
- teach known database storage helpers and loadStoredCredentials() to honor the selected database id from local storage or the URL hash
- sync Settings with the Ygdrassil state machine query and invalidate schema caching when credentials change

## Testing
- npm run build
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cea2ae3dac8327afe273d65d389244