### PR TITLE
Add deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,25 @@
+name: Deploy
+
+on:
+  push:
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run deploy script
+        run: npm run deploy


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow that runs `npm run deploy` on push or manual trigger

## Testing
- not run (workflow definition only)


------
https://chatgpt.com/codex/tasks/task_e_68ceb1c06be083278013c9ce3ed870f1